### PR TITLE
Add Infografias folder and Cesacionismo page

### DIFF
--- a/english/index.html
+++ b/english/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Index of /english/</title>
-    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../style.css">
 </head>
 <body>
     <h1>Index of /english/</h1>
@@ -24,8 +24,13 @@
             </tr>
             <tr>
                 <td><a href="lesson1.html">lesson1.html</a></td>
-                <td>2025-09-03 07:11:53</td>
-                <td>22.45 KB</td>
+                <td>2026-03-25 15:48:13</td>
+                <td>22.43 KB</td>
+            </tr>
+            <tr>
+                <td><a href="lesson1_slides.html">lesson1_slides.html</a></td>
+                <td>2026-03-25 15:48:13</td>
+                <td>19.71 KB</td>
             </tr>
         </tbody>
     </table>

--- a/generate_index.py
+++ b/generate_index.py
@@ -19,7 +19,16 @@ def generate_index_for_dir(dir_path):
         depth = dir_path.count(os.sep) + 1
 
     # Determine relative path for CSS
-    css_path = '../' * depth + 'style.css'
+    if dir_path == '.':
+        css_path = 'style.css'
+    else:
+        # Normalize path to remove leading ./ and count remaining separators
+        normalized_path = os.path.normpath(dir_path)
+        if normalized_path == '.':
+            css_path = 'style.css'
+        else:
+            depth = normalized_path.count(os.sep) + 1
+            css_path = '../' * depth + 'style.css'
 
     # Create a title for the page
     page_title = f"Index of /{dir_path.replace('.', '', 1).lstrip('/')}"

--- a/infografias/cesacionismo.html
+++ b/infografias/cesacionismo.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Entendiendo el Cesacionismo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800&display=swap');
+        body {
+            font-family: 'Inter', sans-serif;
+        }
+    </style>
+</head>
+<body class="min-h-screen bg-slate-50 text-slate-800 p-4 sm:p-8">
+    <!-- Contenedor Principal -->
+    <div class="max-w-5xl mx-auto bg-white shadow-2xl rounded-2xl overflow-hidden border border-slate-200">
+
+        <!-- Cabecera -->
+        <header class="bg-slate-900 text-white p-8 sm:p-12 text-center relative overflow-hidden">
+            <div class="absolute top-0 left-0 w-full h-full opacity-10 pointer-events-none">
+                <!-- Patrón de fondo sutil -->
+                <div class="w-full h-full" style="background-image: radial-gradient(circle at 2px 2px, white 1px, transparent 0); background-size: 32px 32px;"></div>
+            </div>
+            <div class="relative z-10">
+                <h1 class="text-3xl sm:text-5xl font-extrabold tracking-tight mb-4 text-amber-500">
+                    Entendiendo el Cesacionismo
+                </h1>
+                <p class="text-lg sm:text-xl font-light text-slate-300 max-w-2xl mx-auto">
+                    Un resumen visual de la clase magistral del Dr. Sam Waldron sobre el cese de los dones milagrosos en la iglesia.
+                </p>
+            </div>
+        </header>
+
+        <!-- Sección 1: Definición -->
+        <section class="p-8 sm:p-12 border-b border-slate-100">
+            <div class="flex flex-col md:flex-row items-center gap-8">
+                <div class="flex-shrink-0 bg-amber-100 p-6 rounded-full text-amber-600">
+                    <i data-lucide="book-open" class="w-12 h-12"></i>
+                </div>
+                <div>
+                    <h2 class="text-2xl font-bold text-slate-900 mb-3">¿Qué es el Cesacionismo?</h2>
+                    <p class="text-slate-600 leading-relaxed text-lg">
+                        Es la doctrina bíblica que enseña que los <strong>"dones señales"</strong> o dones milagrosos (apóstoles, profetas, hablar en lenguas y obradores de milagros) fueron dados temporalmente a la iglesia primitiva y <strong>cesaron</strong> después de la era apostólica, al completarse el canon de las Escrituras.
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Sección 2: El Argumento en Cascada -->
+        <section class="p-8 sm:p-12 bg-slate-50">
+            <div class="text-center mb-10">
+                <h2 class="text-3xl font-bold text-slate-900 flex justify-center items-center gap-3">
+                    <i data-lucide="layers" class="text-amber-500"></i> El Argumento en Cascada
+                </h2>
+                <p class="text-slate-600 mt-2 max-w-2xl mx-auto">
+                    El Dr. Waldron argumenta que si se demuestra el cese del primer don (el mayor), esto provoca un efecto en cadena que demuestra el cese de los demás.
+                </p>
+            </div>
+
+            <div class="max-w-3xl mx-auto space-y-4">
+
+                <!-- Paso 1 -->
+                <div class="bg-white p-6 rounded-xl shadow-sm border border-slate-200 relative z-10 hover:shadow-md transition-shadow">
+                    <div class="flex items-start gap-4">
+                        <div class="bg-blue-100 text-blue-700 p-3 rounded-lg flex-shrink-0 mt-1">
+                            <i data-lucide="eye" class="w-7 h-7"></i>
+                        </div>
+                        <div>
+                            <h3 class="text-xl font-bold text-slate-800">1. Cesaron los Apóstoles de Cristo</h3>
+                            <p class="text-slate-600 mt-2">
+                                Fueron el <strong>fundamento</strong> de la iglesia (Efesios 2:20). Un requisito estricto era haber sido <strong>testigo ocular</strong> de la resurrección y ser designado por Cristo. Pablo afirma explícitamente ser el último testigo y el último apóstol (1 Corintios 15:8).
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="flex justify-center text-slate-400 -my-2 relative z-0">
+                    <i data-lucide="arrow-down" class="w-8 h-8"></i>
+                </div>
+
+                <!-- Paso 2 -->
+                <div class="bg-white p-6 rounded-xl shadow-sm border border-slate-200 relative z-10 hover:shadow-md transition-shadow">
+                    <div class="flex items-start gap-4">
+                        <div class="bg-purple-100 text-purple-700 p-3 rounded-lg flex-shrink-0 mt-1">
+                            <i data-lucide="message-square" class="w-7 h-7"></i>
+                        </div>
+                        <div>
+                            <h3 class="text-xl font-bold text-slate-800">2. Cesaron los Profetas del NT</h3>
+                            <p class="text-slate-600 mt-2">
+                                Junto con los apóstoles, son parte del fundamento que ya fue puesto. Según Deuteronomio 18, un verdadero profeta es la "boca de Dios" y <strong>nunca se equivoca</strong>. Los supuestos profetas modernos exigen un estándar inferior donde se les permite fallar, lo cual contradice la Biblia.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="flex justify-center text-slate-400 -my-2 relative z-0">
+                    <i data-lucide="arrow-down" class="w-8 h-8"></i>
+                </div>
+
+                <!-- Paso 3 -->
+                <div class="bg-white p-6 rounded-xl shadow-sm border border-slate-200 relative z-10 hover:shadow-md transition-shadow">
+                    <div class="flex items-start gap-4">
+                        <div class="bg-green-100 text-green-700 p-3 rounded-lg flex-shrink-0 mt-1">
+                            <i data-lucide="message-square" class="w-7 h-7"></i>
+                        </div>
+                        <div>
+                            <h3 class="text-xl font-bold text-slate-800">3. Cesó el Don de Lenguas</h3>
+                            <p class="text-slate-600 mt-2">
+                                Las lenguas bíblicas eran idiomas humanos conocidos (Hechos 2). Además, Pablo establece (1 Corintios 14) que las lenguas interpretadas son equivalentes a la profecía. <strong>Si el don de profecía cesó, por consecuencia natural, las lenguas revelatorias también cesaron.</strong>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="flex justify-center text-slate-400 -my-2 relative z-0">
+                    <i data-lucide="arrow-down" class="w-8 h-8"></i>
+                </div>
+
+                <!-- Paso 4 -->
+                <div class="bg-white p-6 rounded-xl shadow-sm border border-slate-200 relative z-10 hover:shadow-md transition-shadow">
+                    <div class="flex items-start gap-4">
+                        <div class="bg-red-100 text-red-700 p-3 rounded-lg flex-shrink-0 mt-1">
+                            <i data-lucide="zap" class="w-7 h-7"></i>
+                        </div>
+                        <div>
+                            <h3 class="text-xl font-bold text-slate-800">4. Cesaron los Obradores de Milagros</h3>
+                            <p class="text-slate-600 mt-2">
+                                Los milagros bíblicos ("señales, maravillas y prodigios") funcionaban como sellos divinos para <strong>autenticar a los mensajeros</strong> (apóstoles y profetas) y confirmar la entrega de nueva revelación (2 Corintios 12:12). Sin nuevos apóstoles ni revelación, los obradores de milagros ya no son necesarios.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+        </section>
+
+        <!-- Sección 3: Aclaraciones Importantes -->
+        <section class="p-8 sm:p-12">
+            <h2 class="text-2xl font-bold text-slate-900 mb-8 text-center">Aclaraciones Teológicas Clave</h2>
+
+            <div class="grid md:grid-cols-2 gap-8">
+
+                <!-- Tarjeta: Milagros M vs m -->
+                <div class="bg-slate-800 text-white p-8 rounded-2xl shadow-lg relative overflow-hidden">
+                    <div class="absolute top-0 right-0 p-4 opacity-20">
+                        <i data-lucide="heart-handshake" class="w-24 h-24"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-amber-400 mb-4 flex items-center gap-2">
+                        <i data-lucide="heart-handshake" class="w-6 h-6"></i> ¿Significa que Dios ya no hace milagros?
+                    </h3>
+                    <p class="text-slate-300 leading-relaxed mb-4">
+                        El Dr. Waldron distingue entre:
+                    </p>
+                    <ul class="space-y-3">
+                        <li class="flex items-start gap-2">
+                            <span class="text-red-400 font-bold">✗</span>
+                            <span><strong>Milagros ("M" mayúscula):</strong> Señales revelatorias dadas a "obradores de milagros" específicos. (Han cesado).</span>
+                        </li>
+                        <li class="flex items-start gap-2">
+                            <span class="text-green-400 font-bold">✓</span>
+                            <span><strong>Milagros ("m" minúscula):</strong> Dios sanando enfermos, respondiendo oraciones y obrando providencialmente de formas inexplicables hoy en día. (Los cesacionistas creen firmemente en esto).</span>
+                        </li>
+                    </ul>
+                </div>
+
+                <!-- Tarjeta: Sueños y Sola Scriptura -->
+                <div class="bg-white border-2 border-slate-200 p-8 rounded-2xl shadow-sm relative overflow-hidden">
+                    <div class="absolute top-0 right-0 p-4 opacity-10 text-slate-900">
+                        <i data-lucide="shield-check" class="w-24 h-24"></i>
+                    </div>
+                    <h3 class="text-xl font-bold text-slate-800 mb-4 flex items-center gap-2">
+                        <i data-lucide="book-marked" class="w-6 h-6 text-amber-600"></i> Canon Cerrado y Sola Scriptura
+                    </h3>
+                    <p class="text-slate-600 leading-relaxed mb-4">
+                        La gran enemiga de la suficiencia de la Biblia (Sola Scriptura) es la doctrina de la revelación continua. Si el canon de la Biblia está cerrado y completo, no necesitamos nuevas revelaciones.
+                    </p>
+                    <div class="bg-slate-50 p-4 rounded-lg border border-slate-100 mt-4">
+                        <h4 class="font-bold text-slate-800 text-sm mb-1">¿Y los sueños o visiones de hoy?</h4>
+                        <p class="text-sm text-slate-600">
+                            Cualquier experiencia subjetiva no tiene autoridad divina sobre la iglesia. Dios puede usar su <em>providencia extraordinaria</em> (ej. un sueño alarmante) para atraer a alguien a Cristo, pero esto no constituye nueva revelación inspirada; todo debe juzgarse por la Biblia.
+                        </p>
+                    </div>
+                </div>
+
+            </div>
+        </section>
+
+        <!-- Footer -->
+        <footer class="bg-slate-900 text-slate-400 text-center py-6 text-sm border-t border-slate-800">
+            <p>Basado en el podcast de Covenant Baptist Theological Seminary (CBTS).</p>
+            <p class="mt-1">Dr. Sam Waldron - Autor de <em>"To Be Continued?"</em></p>
+        </footer>
+
+    </div>
+
+    <script>
+        // Initialize Lucide icons
+        lucide.createIcons();
+    </script>
+</body>
+</html>

--- a/infografias/index.html
+++ b/infografias/index.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Index of /</title>
-    <link rel="stylesheet" href="style.css">
+    <title>Index of /infografias/</title>
+    <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-    <h1>Index of /</h1>
+    <h1>Index of /infografias/</h1>
     <table>
         <thead>
             <tr>
@@ -18,19 +18,14 @@
         </thead>
         <tbody>
             <tr>
-                <td><a href="bible">bible/</a></td>
-                <td>2026-03-25 15:48:13</td>
+                <td><a href="../">Parent Directory</a></td>
+                <td>-</td>
                 <td>-</td>
             </tr>
             <tr>
-                <td><a href="english">english/</a></td>
-                <td>2026-03-25 15:48:13</td>
-                <td>-</td>
-            </tr>
-            <tr>
-                <td><a href="infografias">infografias/</a></td>
-                <td>2026-03-25 15:53:37</td>
-                <td>-</td>
+                <td><a href="cesacionismo.html">cesacionismo.html</a></td>
+                <td>2026-03-25 15:53:33</td>
+                <td>11.84 KB</td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
I have added a new folder called `infografias` (all lowercase, no accents) and a new page `cesacionismo.html` inside it. 

The `cesacionismo.html` page was converted from the provided React code into a plain HTML file that uses Tailwind CSS and Lucide icons via CDN, ensuring compatibility with your existing environment.

I also updated the `generate_index.py` script to correctly handle relative paths for the CSS file and ran it to update the homepage and create the index for the new folder. This ensures that the new folder appears on the homepage and that its contents are correctly listed when clicked.

---
*PR created automatically by Jules for task [17929027317449563023](https://jules.google.com/task/17929027317449563023) started by @ottolopez*